### PR TITLE
Update tokens in examples directory

### DIFF
--- a/examples/app.css
+++ b/examples/app.css
@@ -12,386 +12,335 @@
   }
 }
 
-.dsp-64N-4 {
+.dsp-64N-140 {
   font-size: var(--font-size-64);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-4);
 }
 
-.dsp-57N-4 {
+.dsp-57N-140 {
   font-size: var(--font-size-57);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-4);
 }
 
-.dsp-48N-4 {
+.dsp-48N-140 {
   font-size: var(--font-size-48);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-4);
 }
 
-.std-45B-4 {
+.std-45B-140 {
   font-size: var(--font-size-45);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-4);
-  letter-spacing: 0.02em;
 }
 
-.std-36B-4 {
+.std-36B-140 {
   font-size: var(--font-size-36);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-4);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
-.std-32B-5 {
+.std-32B-150 {
   font-size: var(--font-size-32);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
-.std-28B-5 {
+.std-28B-150 {
   font-size: var(--font-size-28);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
-.std-24B-5 {
+.std-24B-150 {
   font-size: var(--font-size-24);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
   letter-spacing: 0.02em;
 }
 
-.std-22B-5 {
+.std-22B-150 {
   font-size: var(--font-size-22);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
   letter-spacing: 0.02em;
 }
 
-.std-20B-6 {
+.std-20B-160 {
   font-size: var(--font-size-20);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-6);
   letter-spacing: 0.02em;
 }
 
-.std-20B-5 {
+.std-20B-150 {
   font-size: var(--font-size-20);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
   letter-spacing: 0.02em;
 }
 
-.std-18B-6 {
+.std-18B-160 {
   font-size: var(--font-size-18);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-6);
   letter-spacing: 0.02em;
 }
 
-.std-17B-7 {
+.std-17B-170 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-7);
   letter-spacing: 0.02em;
 }
 
-.std-16B-7 {
+.std-16B-170 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-7);
   letter-spacing: 0.02em;
 }
 
-.std-32M-5 {
-  font-size: var(--font-size-32);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
-}
-
-.std-28M-5 {
-  font-size: var(--font-size-28);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
-}
-
-.std-24M-5 {
-  font-size: var(--font-size-24);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
-}
-
-.std-20M-5 {
-  font-size: var(--font-size-20);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
-}
-
-.std-17M-7 {
-  font-size: var(--font-size-17);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-7);
-  letter-spacing: 0.02em;
-}
-
-.std-16M-7 {
+.std-16B-175 {
   font-size: var(--font-size-16);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-7);
+  font-weight: var(--font-weight-700);
+  line-height: var(--line-height-1-75);
   letter-spacing: 0.02em;
 }
 
-.std-45N-4 {
+.std-45N-140 {
   font-size: var(--font-size-45);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-4);
-  letter-spacing: 0.02em;
 }
 
-.std-36N-4 {
+.std-36N-140 {
   font-size: var(--font-size-36);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-4);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
-.std-32N-4 {
+.std-32N-150 {
   font-size: var(--font-size-32);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
-.std-28N-5 {
+.std-28N-150 {
   font-size: var(--font-size-28);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
-.std-26N-5 {
+.std-26N-150 {
   font-size: var(--font-size-26);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
   letter-spacing: 0.02em;
 }
 
-.std-24N-5 {
+.std-24N-150 {
   font-size: var(--font-size-24);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
   letter-spacing: 0.02em;
 }
 
-.std-22N-5 {
+.std-22N-150 {
   font-size: var(--font-size-22);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
   letter-spacing: 0.02em;
 }
 
-.std-20N-5 {
+.std-20N-150 {
   font-size: var(--font-size-20);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
   letter-spacing: 0.02em;
 }
 
-.std-18N-6 {
+.std-18N-160 {
   font-size: var(--font-size-18);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-6);
   letter-spacing: 0.02em;
 }
 
-.std-17N-7 {
+.std-17N-170 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-7);
   letter-spacing: 0.02em;
 }
 
-.std-16N-7 {
+.std-16N-170 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-7);
   letter-spacing: 0.02em;
 }
 
-.dns-17B-3 {
+.std-16N-175 {
+  font-size: var(--font-size-16);
+  font-weight: var(--font-weight-400);
+  line-height: var(--line-height-1-75);
+  letter-spacing: 0.02em;
+}
+
+.dns-17B-130 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-3);
 }
 
-.dns-17B-2 {
+.dns-17B-120 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-2);
 }
 
-.dns-16B-3 {
+.dns-16B-130 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-3);
 }
 
-.dns-16B-2 {
+.dns-16B-120 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-2);
 }
 
-.dns-14B-3 {
+.dns-14B-130 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-3);
 }
 
-.dns-14B-2 {
+.dns-14B-120 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-2);
 }
 
-.dns-17N-3 {
+.dns-17N-130 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-3);
 }
 
-.dns-17N-2 {
+.dns-17N-120 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-2);
 }
 
-.dns-16N-3 {
+.dns-16N-130 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-3);
 }
 
-.dns-16N-2 {
+.dns-16N-120 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-2);
 }
 
-.dns-14N-3 {
+.dns-14N-130 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-3);
 }
 
-.dns-14N-2 {
+.dns-14N-120 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-2);
 }
 
-.oln-17B-1 {
+.oln-17B-100 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-0);
   letter-spacing: 0.02em;
 }
 
-.oln-16B-1 {
+.oln-16B-100 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-0);
   letter-spacing: 0.02em;
 }
 
-.oln-14B-1 {
+.oln-14B-100 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-0);
   letter-spacing: 0.02em;
 }
 
-.oln-17M-1 {
-  font-size: var(--font-size-17);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-0);
-  letter-spacing: 0.02em;
-}
-
-.oln-16M-1 {
-  font-size: var(--font-size-16);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-0);
-  letter-spacing: 0.02em;
-}
-
-.oln-14M-1 {
-  font-size: var(--font-size-14);
-  font-weight: var(--font-weight-500);
-  line-height: var(--line-height-1-0);
-  letter-spacing: 0.02em;
-}
-
-.oln-17N-1 {
+.oln-17N-100 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-0);
   letter-spacing: 0.02em;
 }
 
-.oln-16N-1 {
+.oln-16N-100 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-0);
   letter-spacing: 0.02em;
 }
 
-.oln-14N-1 {
+.oln-14N-100 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-0);
   letter-spacing: 0.02em;
 }
 
-.mono-17B-5 {
+.mono-17B-150 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
 }
 
-.mono-16B-5 {
+.mono-16B-150 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
 }
 
-.mono-14B-5 {
+.mono-14B-150 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-700);
   line-height: var(--line-height-1-5);
 }
 
-.mono-17N-5 {
+.mono-17N-150 {
   font-size: var(--font-size-17);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
 }
 
-.mono-16N-5 {
+.mono-16N-150 {
   font-size: var(--font-size-16);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);
 }
 
-.mono-14N-5 {
+.mono-14N-150 {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-400);
   line-height: var(--line-height-1-5);

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,84 +13,74 @@
   <body>
     <h1>examples</h1>
 
-    <p class="dsp-64N-4">Dsp-64N-4</p>
-    <p class="dsp-57N-4">Dsp-57N-4</p>
-    <p class="dsp-48N-4">Dsp-48N-4</p>
+    <p class="dsp-64N-140">Dsp-64N-140</p>
+    <p class="dsp-57N-140">Dsp-57N-140</p>
+    <p class="dsp-48N-140">Dsp-48N-140</p>
 
     <hr />
 
-    <p class="std-45B-4">Std-45B-4</p>
-    <p class="std-36B-4">Std-36B-4</p>
-    <p class="std-32B-5">Std-32B-5</p>
-    <p class="std-28B-5">Std-28B-5</p>
-    <p class="std-24B-5">Std-24B-5</p>
-    <p class="std-22B-5">Std-22B-5</p>
-    <p class="std-20B-6">Std-20B-6</p>
-    <p class="std-20B-5">Std-20B-5</p>
-    <p class="std-18B-6">Std-18B-6</p>
-    <p class="std-17B-7">Std-17B-7</p>
-    <p class="std-16B-7">Std-16B-7</p>
+    <p class="std-45B-140">Std-45B-140</p>
+    <p class="std-36B-140">Std-36B-140</p>
+    <p class="std-32B-150">Std-32B-150</p>
+    <p class="std-28B-150">Std-28B-150</p>
+    <p class="std-24B-150">Std-24B-150</p>
+    <p class="std-22B-150">Std-22B-150</p>
+    <p class="std-20B-160">Std-20B-160</p>
+    <p class="std-20B-150">Std-20B-150</p>
+    <p class="std-18B-160">Std-18B-160</p>
+    <p class="std-17B-170">Std-17B-170</p>
+    <p class="std-16B-170">Std-16B-170</p>
+    <p class="std-16B-175">Std-16B-175</p>
 
     <hr />
 
-    <p class="std-32M-5">Std-32M-5</p>
-    <p class="std-28M-5">Std-28M-5</p>
-    <p class="std-24M-5">Std-24M-5</p>
-    <p class="std-20M-5">Std-20M-5</p>
-    <p class="std-17M-7">Std-17M-7</p>
-    <p class="std-16M-7">Std-16M-7</p>
+    <p class="std-45N-140">Std-45N-140</p>
+    <p class="std-36N-140">Std-36N-140</p>
+    <p class="std-32N-150">Std-32N-150</p>
+    <p class="std-28N-150">Std-28N-150</p>
+    <p class="std-26N-150">Std-26N-150</p>
+    <p class="std-24N-150">Std-24N-150</p>
+    <p class="std-22N-150">Std-22N-150</p>
+    <p class="std-20N-150">Std-20N-150</p>
+    <p class="std-18N-160">Std-18N-160</p>
+    <p class="std-17N-170">Std-17N-170</p>
+    <p class="std-16N-170">Std-16N-170</p>
+    <p class="std-16N-175">Std-16N-175</p>
 
     <hr />
 
-    <p class="std-45N-4">Std-45N-4</p>
-    <p class="std-36N-4">Std-36N-4</p>
-    <p class="std-32N-4">Std-32N-4</p>
-    <p class="std-28N-5">Std-28N-5</p>
-    <p class="std-26N-5">Std-26N-5</p>
-    <p class="std-24N-5">Std-24N-5</p>
-    <p class="std-22N-5">Std-22N-5</p>
-    <p class="std-20N-5">Std-20N-5</p>
-    <p class="std-18N-6">Std-18N-6</p>
-    <p class="std-17N-7">Std-17N-7</p>
-    <p class="std-16N-7">Std-16N-7</p>
+    <p class="dns-17B-130">Dns-17B-130</p>
+    <p class="dns-17B-120">Dns-17B-120</p>
+    <p class="dns-16B-130">Dns-16B-130</p>
+    <p class="dns-16B-120">Dns-16B-120</p>
+    <p class="dns-14B-130">Dns-14B-130</p>
+    <p class="dns-14B-120">Dns-14B-120</p>
 
     <hr />
 
-    <p class="dns-17B-3">Dns-17B-3</p>
-    <p class="dns-17B-2">Dns-17B-2</p>
-    <p class="dns-16B-3">Dns-16B-3</p>
-    <p class="dns-16B-2">Dns-16B-2</p>
-    <p class="dns-14B-3">Dns-14B-3</p>
-    <p class="dns-14B-2">Dns-14B-2</p>
+    <p class="dns-17N-130">Dns-17N-130</p>
+    <p class="dns-17N-120">Dns-17N-120</p>
+    <p class="dns-16N-130">Dns-16N-130</p>
+    <p class="dns-16N-120">Dns-16N-120</p>
+    <p class="dns-14N-130">Dns-14N-130</p>
+    <p class="dns-14N-120">Dns-14N-120</p>
 
     <hr />
 
-    <p class="dns-17N-3">Dns-17N-3</p>
-    <p class="dns-17N-2">Dns-17N-2</p>
-    <p class="dns-16N-3">Dns-16N-3</p>
-    <p class="dns-16N-2">Dns-16N-2</p>
-    <p class="dns-14N-3">Dns-14N-3</p>
-    <p class="dns-14N-2">Dns-14N-2</p>
+    <p class="oln-17B-100">Oln-17B-100</p>
+    <p class="oln-16B-100">Oln-16B-100</p>
+    <p class="oln-14B-100">Oln-14B-100</p>
+    <p class="oln-17N-100">Oln-17N-100</p>
+    <p class="oln-16N-100">Oln-16N-100</p>
+    <p class="oln-14N-100">Oln-14N-100</p>
 
     <hr />
 
-    <p class="oln-17B-1">Oln-17B-1</p>
-    <p class="oln-16B-1">Oln-16B-1</p>
-    <p class="oln-14B-1">Oln-14B-1</p>
-    <p class="oln-17M-1">Oln-17M-1</p>
-    <p class="oln-16M-1">Oln-16M-1</p>
-    <p class="oln-14M-1">Oln-14M-1</p>
-    <p class="oln-17N-1">Oln-17N-1</p>
-    <p class="oln-16N-1">Oln-16N-1</p>
-    <p class="oln-14N-1">Oln-14N-1</p>
-
-    <hr />
-
-    <p><code class="mono-17B-5">mono-17B-5</code></p>
-    <p><code class="mono-16B-5">mono-16B-5</code></p>
-    <p><code class="mono-14B-5">mono-14B-5</code></p>
-    <p><code class="mono-17N-5">mono-17N-5</code></p>
-    <p><code class="mono-16N-5">mono-16N-5</code></p>
-    <p><code class="mono-14N-5">mono-14N-5</code></p>
+    <p><code class="mono-17B-150">mono-17B-150</code></p>
+    <p><code class="mono-16B-150">mono-16B-150</code></p>
+    <p><code class="mono-14B-150">mono-14B-150</code></p>
+    <p><code class="mono-17N-150">mono-17N-150</code></p>
+    <p><code class="mono-16N-150">mono-16N-150</code></p>
+    <p><code class="mono-14N-150">mono-14N-150</code></p>
   </body>
 </html>

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -5,16 +5,15 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "examples",
-      "version": "1.0.0",
       "dependencies": {
-        "@digital-go-jp/design-tokens": "^0.1.6"
+        "@digital-go-jp/design-tokens": "^0.1.7"
       }
     },
     "node_modules/@digital-go-jp/design-tokens": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@digital-go-jp/design-tokens/-/design-tokens-0.1.6.tgz",
-      "integrity": "sha512-Si1xBZlyqH1SuEpyg81lJd7qQ9xr+SeR6Y6eflnf0WLjCNpNIUJHUF8W+jh/Hp94yAeN/SxZ71+w+GrpIqVuzg==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@digital-go-jp/design-tokens/-/design-tokens-0.1.7.tgz",
+      "integrity": "sha512-apKZ/fF5nj25wcQmBw5Zpfbvp33iioqoInIN2k2SXh7a6bgWksLeb0Jr0jns99Hr+EcI/vdmaculhZbgkqmogA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@digital-go-jp/design-tokens": "^0.1.6"
+    "@digital-go-jp/design-tokens": "^0.1.7"
   }
 }


### PR DESCRIPTION
## 概要

@takumi-hatta-dig 

examples ディレクトリで使っている design-tokens のパッケージのアップグレード（v0.1.7）と、トークン名を最新のものに更新しました。v2.0.3 で削除となっている Medium フォントウェイトのテキストスタイルも削除しています。

## 動作確認

- [x] `examples/index.html` 内のテキストスタイルが正しく適用されていること
