### PR TITLE
upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1113,9 +1113,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@tokens-studio/sd-transforms": "^1.2.7",
+        "@tokens-studio/sd-transforms": "^1.2.8",
         "@tsconfig/node20": "^20.1.4",
         "style-dictionary": "^4.1.4",
         "token-transformer": "^0.0.33",
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@tokens-studio/sd-transforms": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@tokens-studio/sd-transforms/-/sd-transforms-1.2.7.tgz",
-      "integrity": "sha512-1EaSSAqs0sQMW9kXTBKeWoZaX1M2XcI9ngOBm4/LUcQfkuH8GMOox3Xeq4xF9Noroc26BCY21or4PXYW1CtEIw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@tokens-studio/sd-transforms/-/sd-transforms-1.2.8.tgz",
+      "integrity": "sha512-fEWiTjldXbWzkjZEE5uYqKZ35X2bOGRWBcOBrD9kUftNYfM3KNau+JEIyXZhaDIdJa/u/TKyrAqHH0b9r4iegA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@tokens-studio/sd-transforms": "^1.2.7",
+    "@tokens-studio/sd-transforms": "^1.2.8",
     "@tsconfig/node20": "^20.1.4",
     "style-dictionary": "^4.1.4",
     "token-transformer": "^0.0.33",


### PR DESCRIPTION
@digital-go-jp/design-system 

依存パッケージのアップグレードをしました。

style-dictionary の 4.2.0 へのアップグレードは、Prettier 絡みのエラーでビルドができない問題がありそのままにしています。
style-dictionary に[Issue](https://github.com/amzn/style-dictionary/issues/1393) も出したので、これが解決したらアップグレードします。

## 確認方法

以下のコマンドがすべて正常に動作すること

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run type:check`
- [x] `npm run transform-figma-tokens`
- [x] `npm run build`