### PR TITLE
add 6 and 12 border radius

### DIFF
--- a/figma/tokens.json
+++ b/figma/tokens.json
@@ -823,9 +823,17 @@
         "$type": "borderRadius",
         "$value": "4px"
       },
+      "6": {
+        "$type": "borderRadius",
+        "$value": "6px"
+      },
       "8": {
         "$type": "borderRadius",
         "$value": "8px"
+      },
+      "12": {
+        "$type": "borderRadius",
+        "$value": "12px"
       },
       "16": {
         "$type": "borderRadius",


### PR DESCRIPTION
@digital-go-jp/design-system 

borderRadius に `6`, `12` を追加しました。
角丸の値はものによって変わるので制約をあまり持たせない方がいいという意図で、デザイン側でこの Variables を使用はしないですが、実装側ではトークンとして持たせておいた方が嬉しい場面が多々あるので、既存のトークンにない値でよく使われる `6px` と `12px` を追加しています、

これにより tailwind-theme-plugin で 6px 角丸を `rounded-md(Tailwind default)` や `rounded-[6px]`、また config で extend などすることなく `rounded-6` のように使えることを目的としています。