### PR TITLE
upgrade typescript to 5.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@tsconfig/node20": "^20.1.4",
         "style-dictionary": "^4.1.4",
         "tsx": "^4.19.2",
-        "typescript": "^5.6.3"
+        "typescript": "^5.7.2"
       },
       "engines": {
         "node": ">=18"
@@ -2550,9 +2550,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/node20": "^20.1.4",
     "style-dictionary": "^4.1.4",
     "tsx": "^4.19.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.7.2"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
@digital-go-jp/design-system 

TypeScript を最新の 5.7.2 にアップグレードしました。