### PR TITLE
update style dictionary to v4.3.0

### DIFF
--- a/examples/tokens.css
+++ b/examples/tokens.css
@@ -187,7 +187,9 @@
   --line-height-170: 1.7;
   --line-height-175: 1.75;
   --border-radius-4: 0.25rem;
+  --border-radius-6: 0.375rem;
   --border-radius-8: 0.5rem;
+  --border-radius-12: 0.75rem;
   --border-radius-16: 1rem;
   --border-radius-24: 1.5rem;
   --border-radius-32: 2rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@tokens-studio/sd-transforms": "^1.2.8",
+        "@tokens-studio/sd-transforms": "^1.2.9",
         "@tsconfig/node20": "^20.1.4",
-        "style-dictionary": "^4.1.4",
+        "style-dictionary": "^4.3.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2"
       },
@@ -733,9 +733,9 @@
       }
     },
     "node_modules/@tokens-studio/sd-transforms": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@tokens-studio/sd-transforms/-/sd-transforms-1.2.8.tgz",
-      "integrity": "sha512-fEWiTjldXbWzkjZEE5uYqKZ35X2bOGRWBcOBrD9kUftNYfM3KNau+JEIyXZhaDIdJa/u/TKyrAqHH0b9r4iegA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@tokens-studio/sd-transforms/-/sd-transforms-1.2.9.tgz",
+      "integrity": "sha512-doRL3tjhwmSck/9fH0X1mlBA6derw+8wpmi5hbG2vhAmvc8F89MxIN6JCKSIbVIJNvaprDVlQqSzXLG7Ug7F9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/path-unified": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/path-unified/-/path-unified-0.1.0.tgz",
-      "integrity": "sha512-/Oaz9ZJforrkmFrwkR/AcvjVsCAwGSJHO0X6O6ISj8YeFbATjIEBXLDcZfnK3MO4uvCBrJTdVIxdOc79PMqSdg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/path-unified/-/path-unified-0.2.0.tgz",
+      "integrity": "sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2075,6 +2075,22 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -2420,9 +2436,9 @@
       }
     },
     "node_modules/style-dictionary": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.1.4.tgz",
-      "integrity": "sha512-JCfF5/my6yTBp8qtcxdEY1JwR3JDq9fyosoJ+mpl/jMVZ0zVNsseIDJA/xMmm0P3GwuryHkwJwBMkm99HlXhfQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.3.0.tgz",
+      "integrity": "sha512-bwasoBSGzIUzeZKR9HKD+qaTFzcVc3SAx+ziD41DAbDZ8OGFnfXfU3Nb3xdZb8VhxNKT21MowR5jOFvdJE9ayQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2437,7 +2453,8 @@
         "is-plain-obj": "^4.1.0",
         "json5": "^2.2.2",
         "patch-package": "^8.0.0",
-        "path-unified": "^0.1.0",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
         "tinycolor2": "^1.6.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@tokens-studio/sd-transforms": "^1.2.8",
+    "@tokens-studio/sd-transforms": "^1.2.9",
     "@tsconfig/node20": "^20.1.4",
-    "style-dictionary": "^4.1.4",
+    "style-dictionary": "^4.3.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"
   },


### PR DESCRIPTION
@digital-go-jp/design-system 

以前 #159 で Prettier 絡みの問題で Style Dictionary はアップグレードできませんでしたが、v4.3.0 で修正されていたのでアップグレードしました。

特にビルドも問題なく動作していそうです。