### PR TITLE
Add simplified CSS token output without specific tokens

### DIFF
--- a/style-dictionary/config.json
+++ b/style-dictionary/config.json
@@ -14,6 +14,14 @@
           "options": {
             "outputReferences": true
           }
+        },
+        {
+          "destination": "tokens-simple.css",
+          "format": "css/variables",
+          "filter": "tokens-simple-filter",
+          "options": {
+            "outputReferences": true
+          }
         }
       ]
     },

--- a/style-dictionary/transform.ts
+++ b/style-dictionary/transform.ts
@@ -1,21 +1,37 @@
-import { register } from '@tokens-studio/sd-transforms';
-import StyleDictionary from 'style-dictionary';
+import { register } from "@tokens-studio/sd-transforms";
+import StyleDictionary from "style-dictionary";
 
 register(StyleDictionary, {
   excludeParentKeys: true,
 });
 
 StyleDictionary.registerFilter({
-  name: 'tokens-filter',
+  name: "tokens-filter",
   filter: (token) => {
     if (token.path.length === 0) {
       return true;
     }
-    return token.path[0] !== 'tokenSetOrder';
+    return token.path[0] !== "tokenSetOrder";
   },
 });
 
-const sd = new StyleDictionary('style-dictionary/config.json');
+StyleDictionary.registerFilter({
+  name: "tokens-simple-filter",
+  filter: (token) => {
+    if (token.path.length === 0) {
+      return true;
+    }
+    if (token.path[0] === "tokenSetOrder") {
+      return false;
+    }
+
+    // Exclude specified properties
+    const excludedTypes = ["fontWeight", "fontSize", "lineHeight", "dimension"];
+    return !excludedTypes.includes(token.$type || "");
+  },
+});
+
+const sd = new StyleDictionary("style-dictionary/config.json");
 
 const run = async (sd: StyleDictionary) => {
   await sd.hasInitialized;


### PR DESCRIPTION
tokens-simple.css を新たに出力するようにしました。これはtokens.cssから、変数名に値が含まれるカスタムプロパティ（つまり余計な抽象化でしかないカスタムプロパティ）を除外したものです。