### PR TITLE
chore: update Dependabot directory to point to /builder/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/" # Location of package manifests
+    directory: "/builder/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
[v1.1.0](https://github.com/digital-go-jp/design-tokens/releases/tag/v1.1.0) のリリースでディレクトリ構造を変更してから、Dependabot が動作していなかったので、dependabot.yml のディレクトリの指定を修正